### PR TITLE
Fix "Unknown option -q" error on Linux

### DIFF
--- a/functions/battery.info.linux.fish
+++ b/functions/battery.info.linux.fish
@@ -8,7 +8,7 @@ function battery.info.linux --no-scope-shadowing
     set -l upo (upower -i $devices)
 
     set __battery_is_plugged false
-    contains -q -- charging $upo; and set __battery_is_plugged true
+    contains -- charging $upo; and set __battery_is_plugged true
     set __battery_is_charging $__battery_is_plugged
 
     set __battery_max_cap (string match -r 'energy-full:\\s+([.\\d]+)' $upo)[2]


### PR DESCRIPTION
On my linux laptop, running `battery` gave me:

```
contains: Unknown option “-q”

~/.config/fish/functions/battery.info.linux.fish (line 11):
    contains -q -- charging $upo; and set __battery_is_plugged true
    ^
in function 'battery.info.linux'
        called on line 9 of file ~/.config/fish/functions/battery.info.fish
in function 'battery.info'
        called on line 26 of file ~/.config/fish/functions/battery.fish
in function 'battery'

(Type 'help contains' for related documentation)
```

I assume the `contains -q` was a mistake by analogy with `command -q`, and hard to spot if you don't have a linux laptop.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/halostatue/fish-battery/1)
<!-- Reviewable:end -->
